### PR TITLE
Simplify nested all filters

### DIFF
--- a/style.json
+++ b/style.json
@@ -485,7 +485,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "path"]]
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "path"]
       ],
       "paint": {
         "line-color": "#cba",
@@ -809,11 +810,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!=", "brunnel", "tunnel"],
-          ["in", "class", "minor", "service", "track"]
-        ]
+        ["!=", "brunnel", "tunnel"],
+        ["in", "class", "minor", "service", "track"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -934,7 +932,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["!in", "brunnel", "bridge", "tunnel"], ["==", "class", "path"]]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "path"]
       ],
       "paint": {
         "line-color": "#cba",
@@ -1004,11 +1003,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!=", "brunnel", "tunnel"],
-          ["in", "class", "minor", "service", "track"]
-        ]
+        ["!=", "brunnel", "tunnel"],
+        ["in", "class", "minor", "service", "track"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -1047,11 +1043,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["in", "class", "primary"]
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "primary"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1072,11 +1065,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["in", "class", "trunk"]
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "trunk"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1098,11 +1088,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "motorway"]
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1123,7 +1110,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+        ["==", "class", "transit"],
+        ["!in", "brunnel", "tunnel"]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -1140,7 +1128,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+        ["==", "class", "transit"],
+        ["!in", "brunnel", "tunnel"]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -1158,7 +1147,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "class", "rail"], ["has", "service"]]
+        ["==", "class", "rail"],
+        ["has", "service"]
       ],
       "paint": {
         "line-color": "hsla(0, 0%, 73%, 0.77)",
@@ -1174,7 +1164,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "class", "rail"], ["has", "service"]]
+        ["==", "class", "rail"],
+        ["has", "service"]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -1192,12 +1183,9 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!has", "service"],
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "rail"]
-        ]
+        ["!has", "service"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "rail"]
       ],
       "paint": {
         "line-color": "#bbb",
@@ -1213,12 +1201,9 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        [
-          "all",
-          ["!has", "service"],
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "rail"]
-        ]
+        ["!has", "service"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "rail"]
       ],
       "paint": {
         "line-color": "#bbb",
@@ -1342,7 +1327,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "bridge"], ["==", "class", "path"]]
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "path"]
       ],
       "paint": {
         "line-color": "#f8f4f0",
@@ -1358,7 +1344,8 @@
       "filter": [
         "all",
         ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "bridge"], ["==", "class", "path"]]
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "path"]
       ],
       "paint": {
         "line-color": "#cba",


### PR DESCRIPTION
Simplify nested `all` filters.

* Nested `all` filter can be flattened.
* Make these filters compatible with maputnik

Not sure about the json formatting. See https://github.com/openmaptiles/osm-bright-gl-style/issues/24