### PR TITLE
Format style with gl-style-format

### DIFF
--- a/style.json
+++ b/style.json
@@ -1,2942 +1,26 @@
 {
-  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key={key}",
-  "id": "bright",
-  "layers": [{
-    "id": "background",
-    "paint": {
-      "background-color": "#f8f4f0"
-    },
-    "type": "background"
-  }, {
-    "filter": ["==", "subclass", "glacier"],
-    "id": "landcover-glacier",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "#fff",
-      "fill-opacity": {
-        "base": 1,
-        "stops": [
-          [0, 0.9],
-          [10, 0.3]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "landcover",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["in", "class", "residential", "suburb", "neighbourhood"]],
-    "id": "landuse-residential",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": {
-        "base": 1,
-        "stops": [
-          [12, "hsla(30, 19%, 90%, 0.4)"],
-          [16, "hsla(30, 19%, 90%, 0.2)"]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["==", "$type", "Polygon"],
-      ["==", "class", "commercial"]
-    ],
-    "id": "landuse-commercial",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "hsla(0, 60%, 87%, 0.23)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["==", "$type", "Polygon"],
-      ["==", "class", "industrial"]
-    ],
-    "id": "landuse-industrial",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "hsla(49, 100%, 88%, 0.34)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "cemetery"],
-    "id": "landuse-cemetery",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "#e0e4dd"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "hospital"],
-    "id": "landuse-hospital",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "#fde"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "school"],
-    "id": "landuse-school",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "#f0e8f8"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "railway"],
-    "id": "landuse-railway",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "hsla(30, 19%, 90%, 0.4)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landuse",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "wood"],
-    "id": "landcover-wood",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-antialias": {
-        "base": 1,
-        "stops": [
-          [0, false],
-          [9, true]
-        ]
-      },
-      "fill-color": "#6a4",
-      "fill-opacity": 0.1,
-      "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "landcover",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "grass"],
-    "id": "landcover-grass",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "#d8e8c8",
-      "fill-opacity": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "landcover",
-    "type": "fill"
-  }, {
-    "filter": ["==", "class", "public_park"],
-    "id": "landcover-grass-park",
-    "metadata": {
-      "mapbox:group": "1444849388993.3071"
-    },
-    "paint": {
-      "fill-color": "#d8e8c8",
-      "fill-opacity": 0.8
-    },
-    "source": "openmaptiles",
-    "source-layer": "park",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["in", "class", "river", "stream", "canal"],
-      ["==", "brunnel", "tunnel"]
-    ],
-    "id": "waterway_tunnel",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "minzoom": 14,
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-dasharray": [2, 4],
-      "line-width": {
-        "base": 1.3,
-        "stops": [
-          [13, 0.5],
-          [20, 6]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "class", "canal", "river", "stream"],
-      ["==", "intermittent", 0]
-    ],
-    "id": "waterway-other",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-width": {
-        "base": 1.3,
-        "stops": [
-          [13, 0.5],
-          [20, 2]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "class", "canal", "river", "stream"],
-      ["==", "intermittent", 1]
-    ],
-    "id": "waterway-other-intermittent",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-width": {
-        "base": 1.3,
-        "stops": [
-          [13, 0.5],
-          [20, 2]
-        ]
-      },
-      "line-dasharray": [4, 3]
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "class", "canal", "stream"],
-      ["!=", "brunnel", "tunnel"],
-      ["==", "intermittent", 0]
-    ],
-    "id": "waterway-stream-canal",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-width": {
-        "base": 1.3,
-        "stops": [
-          [13, 0.5],
-          [20, 6]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "class", "canal", "stream"],
-      ["!=", "brunnel", "tunnel"],
-      ["==", "intermittent", 1]
-    ],
-    "id": "waterway-stream-canal-intermittent",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-width": {
-        "base": 1.3,
-        "stops": [
-          [13, 0.5],
-          [20, 6]
-        ]
-      },
-      "line-dasharray": [4, 3]
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "class", "river"],
-      ["!=", "brunnel", "tunnel"],
-      ["==", "intermittent", 0]
-    ],
-    "id": "waterway-river",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [10, 0.8],
-          [20, 6]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "class", "river"],
-      ["!=", "brunnel", "tunnel"],
-      ["==", "intermittent", 1]
-    ],
-    "id": "waterway-river-intermittent",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "line-color": "#a0c8f0",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [10, 0.8],
-          [20, 6]
-        ]
-      },
-      "line-dasharray": [3, 2.5]
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "line"
-  }, {
-    "filter": ["==", "$type", "Polygon"],
-    "id": "water-offset",
-    "layout": {
-      "visibility": "visible"
-    },
-    "maxzoom": 8,
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "fill-color": "#a0c8f0",
-      "fill-opacity": 1,
-      "fill-translate": {
-        "base": 1,
-        "stops": [
-          [6, [2, 0]],
-          [8, [0, 0]]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "water",
-    "type": "fill"
-  }, {
-    "id": "water",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "fill-color": "hsl(210, 67%, 85%)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "water",
-    "type": "fill",
-    "filter": ["all", ["!=", "intermittent", 1]]
-  }, {
-    "id": "water-intermittent",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "fill-color": "hsl(210, 67%, 85%)",
-      "fill-opacity": 0.7
-    },
-    "source": "openmaptiles",
-    "source-layer": "water",
-    "type": "fill",
-    "filter": ["all", ["==", "intermittent", 1]]
-  }, {
-    "id": "water-pattern",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "fill-pattern": "wave",
-      "fill-translate": [0, 2.5]
-    },
-    "source": "openmaptiles",
-    "source-layer": "water",
-    "type": "fill",
-    "filter": ["all"]
-  }, {
-    "filter": ["==", "subclass", "ice_shelf"],
-    "id": "landcover-ice-shelf",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "fill-color": "#fff",
-      "fill-opacity": {
-        "base": 1,
-        "stops": [
-          [0, 0.9],
-          [10, 0.3]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "landcover",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["==", "class", "sand"]],
-    "id": "landcover-sand",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849382550.77"
-    },
-    "paint": {
-      "fill-color": "rgba(245, 238, 188, 1)",
-      "fill-opacity": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "landcover",
-    "type": "fill"
-  }, {
-    "id": "building",
-    "metadata": {
-      "mapbox:group": "1444849364238.8171"
-    },
-    "paint": {
-      "fill-antialias": true,
-      "fill-color": {
-        "base": 1,
-        "stops": [
-          [15.5, "#f2eae2"],
-          [16, "#dfdbd7"]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "building",
-    "type": "fill"
-  }, {
-    "id": "building-top",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849364238.8171"
-    },
-    "paint": {
-      "fill-color": "#f2eae2",
-      "fill-opacity": {
-        "base": 1,
-        "stops": [
-          [13, 0],
-          [16, 1]
-        ]
-      },
-      "fill-outline-color": "#dfdbd7",
-      "fill-translate": {
-        "base": 1,
-        "stops": [
-          [14, [0, 0]],
-          [16, [-2, -2]]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "building",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["in", "class", "service", "track"]
-    ],
-    "id": "tunnel-service-track-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#cfcdca",
-      "line-dasharray": [0.5, 0.25],
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15, 1],
-          [16, 4],
-          [20, 11]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["==", "class", "minor"]
-    ],
-    "id": "tunnel-minor-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#cfcdca",
-      "line-opacity": {
-        "stops": [
-          [12, 0],
-          [12.5, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12, 0.5],
-          [13, 1],
-          [14, 4],
-          [20, 15]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["in", "class", "secondary", "tertiary"]
-    ],
-    "id": "tunnel-secondary-tertiary-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [8, 1.5],
-          [20, 17]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["in", "class", "primary", "trunk"]
-    ],
-    "id": "tunnel-trunk-primary-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [5, 0.4],
-          [6, 0.6],
-          [7, 1.5],
-          [20, 22]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["==", "class", "motorway"]
-    ],
-    "id": "tunnel-motorway-casing",
-    "layout": {
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-dasharray": [0.5, 0.25],
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [5, 0.4],
-          [6, 0.6],
-          [7, 1.5],
-          [20, 22]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "brunnel", "tunnel"],
-        ["==", "class", "path"]
-      ]
-    ],
-    "id": "tunnel-path",
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#cba",
-      "line-dasharray": [1.5, 0.75],
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15, 1.2],
-          [20, 4]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["in", "class", "service", "track"]
-    ],
-    "id": "tunnel-service-track",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#fff",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15.5, 0],
-          [16, 2],
-          [20, 7.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["==", "class", "minor_road"]
-    ],
-    "id": "tunnel-minor",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#fff",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [13.5, 0],
-          [14, 2.5],
-          [20, 11.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["in", "class", "secondary", "tertiary"]
-    ],
-    "id": "tunnel-secondary-tertiary",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#fff4c6",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 10]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["in", "class", "primary", "trunk"]
-    ],
-    "id": "tunnel-trunk-primary",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#fff4c6",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["==", "class", "motorway"]
-    ],
-    "id": "tunnel-motorway",
-    "layout": {
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#ffdaa6",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "tunnel"],
-      ["==", "class", "rail"]
-    ],
-    "id": "tunnel-railway",
-    "metadata": {
-      "mapbox:group": "1444849354174.1904"
-    },
-    "paint": {
-      "line-color": "#bbb",
-      "line-dasharray": [2, 2],
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14, 0.4],
-          [15, 0.75],
-          [20, 2]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "class", "ferry"]],
-    "id": "ferry",
-    "layout": {
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "paint": {
-      "line-color": "rgba(108, 159, 182, 1)",
-      "line-dasharray": [2, 2],
-      "line-width": 1.1
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "class", "taxiway"]],
-    "id": "aeroway-taxiway-casing",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 12,
-    "paint": {
-      "line-color": "rgba(153, 153, 153, 1)",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.5,
-        "stops": [
-          [11, 2],
-          [17, 12]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "aeroway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "class", "runway"]],
-    "id": "aeroway-runway-casing",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 12,
-    "paint": {
-      "line-color": "rgba(153, 153, 153, 1)",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.5,
-        "stops": [
-          [11, 5],
-          [17, 55]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "aeroway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "Polygon"],
-      ["in", "class", "runway", "taxiway"]
-    ],
-    "id": "aeroway-area",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 4,
-    "paint": {
-      "fill-color": "rgba(255, 255, 255, 1)",
-      "fill-opacity": {
-        "base": 1,
-        "stops": [
-          [13, 0],
-          [14, 1]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "aeroway",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["in", "class", "taxiway"],
-      ["==", "$type", "LineString"]
-    ],
-    "id": "aeroway-taxiway",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 4,
-    "paint": {
-      "line-color": "rgba(255, 255, 255, 1)",
-      "line-opacity": {
-        "base": 1,
-        "stops": [
-          [11, 0],
-          [12, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.5,
-        "stops": [
-          [11, 1],
-          [17, 10]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "aeroway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "class", "runway"],
-      ["==", "$type", "LineString"]
-    ],
-    "id": "aeroway-runway",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 4,
-    "paint": {
-      "line-color": "rgba(255, 255, 255, 1)",
-      "line-opacity": {
-        "base": 1,
-        "stops": [
-          [11, 0],
-          [12, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.5,
-        "stops": [
-          [11, 4],
-          [17, 50]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "aeroway",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "Polygon"],
-      ["==", "class", "pier"]
-    ],
-    "id": "road_area_pier",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {},
-    "paint": {
-      "fill-antialias": true,
-      "fill-color": "#f8f4f0"
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["in", "class", "pier"]
-    ],
-    "id": "road_pier",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "metadata": {},
-    "paint": {
-      "line-color": "#f8f4f0",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15, 1],
-          [17, 4]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "Polygon"],
-      ["!in", "class", "pier"]
-    ],
-    "id": "highway-area",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "fill-antialias": false,
-      "fill-color": "hsla(0, 0%, 89%, 0.56)",
-      "fill-opacity": 0.9,
-      "fill-outline-color": "#cfcdca"
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "fill"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["==", "class", "motorway_link"]
-    ],
-    "id": "highway-motorway-link-casing",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 12,
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12, 1],
-          [13, 3],
-          [14, 4],
-          [20, 15]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["in", "class", "primary_link", "secondary_link", "tertiary_link", "trunk_link"]
-    ],
-    "id": "highway-link-casing",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 13,
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12, 1],
-          [13, 3],
-          [14, 4],
-          [20, 15]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!=", "brunnel", "tunnel"],
-        ["in", "class", "minor", "service", "track"]
-      ]
-    ],
-    "id": "highway-minor-casing",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#cfcdca",
-      "line-opacity": {
-        "stops": [
-          [12, 0],
-          [12.5, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12, 0.5],
-          [13, 1],
-          [14, 4],
-          [20, 15]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["in", "class", "secondary", "tertiary"]
-    ],
-    "id": "highway-secondary-tertiary-casing",
-    "layout": {
-      "line-cap": "butt",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [8, 1.5],
-          [20, 17]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["in", "class", "primary"]
-    ],
-    "id": "highway-primary-casing",
-    "layout": {
-      "line-cap": "butt",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 5,
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": {
-        "stops": [
-          [7, 0],
-          [8, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [7, 0],
-          [8, 0.6],
-          [9, 1.5],
-          [20, 22]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["in", "class", "trunk"]
-    ],
-    "id": "highway-trunk-casing",
-    "layout": {
-      "line-cap": "butt",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 5,
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": {
-        "stops": [
-          [5, 0],
-          [6, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [5, 0],
-          [6, 0.6],
-          [7, 1.5],
-          [20, 22]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["==", "class", "motorway"]
-    ],
-    "id": "highway-motorway-casing",
-    "layout": {
-      "line-cap": "butt",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 4,
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": {
-        "stops": [
-          [4, 0],
-          [5, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [4, 0],
-          [5, 0.4],
-          [6, 0.6],
-          [7, 1.5],
-          [20, 22]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "path"]
-      ]
-    ],
-    "id": "highway-path",
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#cba",
-      "line-dasharray": [1.5, 0.75],
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15, 1.2],
-          [20, 4]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["==", "class", "motorway_link"]
-    ],
-    "id": "highway-motorway-link",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 12,
-    "paint": {
-      "line-color": "#fc8",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12.5, 0],
-          [13, 1.5],
-          [14, 2.5],
-          [20, 11.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["in", "class", "primary_link", "secondary_link", "tertiary_link", "trunk_link"]
-    ],
-    "id": "highway-link",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 13,
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12.5, 0],
-          [13, 1.5],
-          [14, 2.5],
-          [20, 11.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!=", "brunnel", "tunnel"],
-        ["in", "class", "minor", "service", "track"]
-      ]
-    ],
-    "id": "highway-minor",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#fff",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [13.5, 0],
-          [14, 2.5],
-          [20, 11.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!in", "brunnel", "bridge", "tunnel"],
-      ["in", "class", "secondary", "tertiary"]
-    ],
-    "id": "highway-secondary-tertiary",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [8, 0.5],
-          [20, 13]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "primary"]
-      ]
-    ],
-    "id": "highway-primary",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [8.5, 0],
-          [9, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "trunk"]
-      ]
-    ],
-    "id": "highway-trunk",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "motorway"]
-      ]
-    ],
-    "id": "highway-motorway",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "minzoom": 5,
-    "paint": {
-      "line-color": "#fc8",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "class", "transit"],
-        ["!in", "brunnel", "tunnel"]
-      ]
-    ],
-    "id": "railway-transit",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "hsla(0, 0%, 73%, 0.77)",
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14, 0.4],
-          [20, 1]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "class", "transit"],
-        ["!in", "brunnel", "tunnel"]
-      ]
-    ],
-    "id": "railway-transit-hatching",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "hsla(0, 0%, 73%, 0.68)",
-      "line-dasharray": [0.2, 8],
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14.5, 0],
-          [15, 2],
-          [20, 6]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "class", "rail"],
-        ["has", "service"]
-      ]
-    ],
-    "id": "railway-service",
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "hsla(0, 0%, 73%, 0.77)",
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14, 0.4],
-          [20, 1]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "class", "rail"],
-        ["has", "service"]
-      ]
-    ],
-    "id": "railway-service-hatching",
-    "layout": {
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "hsla(0, 0%, 73%, 0.68)",
-      "line-dasharray": [0.2, 8],
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14.5, 0],
-          [15, 2],
-          [20, 6]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!has", "service"],
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "rail"]
-      ]
-    ],
-    "id": "railway",
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#bbb",
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14, 0.4],
-          [15, 0.75],
-          [20, 2]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["!has", "service"],
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "rail"]
-      ]
-    ],
-    "id": "railway-hatching",
-    "metadata": {
-      "mapbox:group": "1444849345966.4436"
-    },
-    "paint": {
-      "line-color": "#bbb",
-      "line-dasharray": [0.2, 8],
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14.5, 0],
-          [15, 3],
-          [20, 8]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["==", "class", "motorway_link"]
-    ],
-    "id": "bridge-motorway-link-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12, 1],
-          [13, 3],
-          [14, 4],
-          [20, 15]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["in", "class", "primary_link", "secondary_link", "tertiary_link", "trunk_link"]
-    ],
-    "id": "bridge-link-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12, 1],
-          [13, 3],
-          [14, 4],
-          [20, 15]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["in", "class", "secondary", "tertiary"]
-    ],
-    "id": "bridge-secondary-tertiary-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-opacity": 1,
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [8, 1.5],
-          [20, 28]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["in", "class", "primary", "trunk"]
-    ],
-    "id": "bridge-trunk-primary-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "hsl(28, 76%, 67%)",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [5, 0.4],
-          [6, 0.6],
-          [7, 1.5],
-          [20, 26]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["==", "class", "motorway"]
-    ],
-    "id": "bridge-motorway-casing",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#e9ac77",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [5, 0.4],
-          [6, 0.6],
-          [7, 1.5],
-          [20, 22]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "brunnel", "bridge"],
-        ["==", "class", "path"]
-      ]
-    ],
-    "id": "bridge-path-casing",
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#f8f4f0",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15, 1.2],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["all", ["==", "brunnel", "bridge"],
-        ["==", "class", "path"]
-      ]
-    ],
-    "id": "bridge-path",
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#cba",
-      "line-dasharray": [1.5, 0.75],
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [15, 1.2],
-          [20, 4]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["==", "class", "motorway_link"]
-    ],
-    "id": "bridge-motorway-link",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#fc8",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12.5, 0],
-          [13, 1.5],
-          [14, 2.5],
-          [20, 11.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["in", "class", "primary_link", "secondary_link", "tertiary_link", "trunk_link"]
-    ],
-    "id": "bridge-link",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [12.5, 0],
-          [13, 1.5],
-          [14, 2.5],
-          [20, 11.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["in", "class", "secondary", "tertiary"]
-    ],
-    "id": "bridge-secondary-tertiary",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 20]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["in", "class", "primary", "trunk"]
-    ],
-    "id": "bridge-trunk-primary",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#fea",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["==", "class", "motorway"]
-    ],
-    "id": "bridge-motorway",
-    "layout": {
-      "line-join": "round"
-    },
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#fc8",
-      "line-width": {
-        "base": 1.2,
-        "stops": [
-          [6.5, 0],
-          [7, 0.5],
-          [20, 18]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["==", "class", "rail"]
-    ],
-    "id": "bridge-railway",
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#bbb",
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14, 0.4],
-          [15, 0.75],
-          [20, 2]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "brunnel", "bridge"],
-      ["==", "class", "rail"]
-    ],
-    "id": "bridge-railway-hatching",
-    "metadata": {
-      "mapbox:group": "1444849334699.1902"
-    },
-    "paint": {
-      "line-color": "#bbb",
-      "line-dasharray": [0.2, 8],
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [14.5, 0],
-          [15, 3],
-          [20, 8]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["==", "class", "cable_car"],
-    "id": "cablecar",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "minzoom": 13,
-    "paint": {
-      "line-color": "hsl(0, 0%, 70%)",
-      "line-width": {
-        "base": 1,
-        "stops": [
-          [11, 1],
-          [19, 2.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["==", "class", "cable_car"],
-    "id": "cablecar-dash",
-    "layout": {
-      "line-cap": "round",
-      "visibility": "visible"
-    },
-    "minzoom": 13,
-    "paint": {
-      "line-color": "hsl(0, 0%, 70%)",
-      "line-dasharray": [2, 3],
-      "line-width": {
-        "base": 1,
-        "stops": [
-          [11, 3],
-          [19, 5.5]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "line"
-  }, {
-    "filter": ["all", [">=", "admin_level", 4],
-      ["<=", "admin_level", 8],
-      ["!=", "maritime", 1]
-    ],
-    "id": "boundary-land-level-4",
-    "layout": {
-      "line-join": "round"
-    },
-    "paint": {
-      "line-color": "#9e9cab",
-      "line-dasharray": [3, 1, 1, 1],
-      "line-width": {
-        "base": 1.4,
-        "stops": [
-          [4, 0.4],
-          [5, 1],
-          [12, 3]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "boundary",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "admin_level", 2],
-      ["!=", "maritime", 1],
-      ["!=", "disputed", 1]
-    ],
-    "id": "boundary-land-level-2",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "paint": {
-      "line-color": "hsl(248, 7%, 66%)",
-      "line-width": {
-        "base": 1,
-        "stops": [
-          [0, 0.6],
-          [4, 1.4],
-          [5, 2],
-          [12, 8]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "boundary",
-    "type": "line"
-  }, {
-    "filter": ["all", ["!=", "maritime", 1],
-      ["==", "disputed", 1]
-    ],
-    "id": "boundary-land-disputed",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "paint": {
-      "line-color": "hsl(248, 7%, 70%)",
-      "line-dasharray": [1, 3],
-      "line-width": {
-        "base": 1,
-        "stops": [
-          [0, 0.6],
-          [4, 1.4],
-          [5, 2],
-          [12, 8]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "boundary",
-    "type": "line"
-  }, {
-    "filter": ["all", ["in", "admin_level", 2, 4],
-      ["==", "maritime", 1]
-    ],
-    "id": "boundary-water",
-    "layout": {
-      "line-cap": "round",
-      "line-join": "round"
-    },
-    "paint": {
-      "line-color": "rgba(154, 189, 214, 1)",
-      "line-opacity": {
-        "stops": [
-          [6, 0.6],
-          [10, 1]
-        ]
-      },
-      "line-width": {
-        "base": 1,
-        "stops": [
-          [0, 0.6],
-          [4, 1.4],
-          [5, 2],
-          [12, 8]
-        ]
-      }
-    },
-    "source": "openmaptiles",
-    "source-layer": "boundary",
-    "type": "line"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["has", "name"]
-    ],
-    "id": "waterway-name",
-    "layout": {
-      "symbol-placement": "line",
-      "symbol-spacing": 350,
-      "text-field": "{name:latin} {name:nonlatin}",
-      "text-font": ["Noto Sans Italic"],
-      "text-letter-spacing": 0.2,
-      "text-max-width": 5,
-      "text-rotation-alignment": "map",
-      "text-size": 14
-    },
-    "minzoom": 13,
-    "paint": {
-      "text-color": "#74aee9",
-      "text-halo-color": "rgba(255,255,255,0.7)",
-      "text-halo-width": 1.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "waterway",
-    "type": "symbol"
-  }, {
-    "filter": ["==", "$type", "LineString"],
-    "id": "water-name-lakeline",
-    "layout": {
-      "symbol-placement": "line",
-      "symbol-spacing": 350,
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Italic"],
-      "text-letter-spacing": 0.2,
-      "text-max-width": 5,
-      "text-rotation-alignment": "map",
-      "text-size": 14
-    },
-    "paint": {
-      "text-color": "#74aee9",
-      "text-halo-color": "rgba(255,255,255,0.7)",
-      "text-halo-width": 1.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "water_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "Point"],
-      ["==", "class", "ocean"]
-    ],
-    "id": "water-name-ocean",
-    "layout": {
-      "symbol-placement": "point",
-      "symbol-spacing": 350,
-      "text-field": "{name:latin}",
-      "text-font": ["Noto Sans Italic"],
-      "text-letter-spacing": 0.2,
-      "text-max-width": 5,
-      "text-rotation-alignment": "map",
-      "text-size": 14
-    },
-    "paint": {
-      "text-color": "#74aee9",
-      "text-halo-color": "rgba(255,255,255,0.7)",
-      "text-halo-width": 1.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "water_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "Point"],
-      ["!in", "class", "ocean"]
-    ],
-    "id": "water-name-other",
-    "layout": {
-      "symbol-placement": "point",
-      "symbol-spacing": 350,
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Italic"],
-      "text-letter-spacing": 0.2,
-      "text-max-width": 5,
-      "text-rotation-alignment": "map",
-      "text-size": {
-        "stops": [
-          [0, 10],
-          [6, 14]
-        ]
-      },
-      "visibility": "visible"
-    },
-    "paint": {
-      "text-color": "#74aee9",
-      "text-halo-color": "rgba(255,255,255,0.7)",
-      "text-halo-width": 1.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "water_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "Point"],
-      [">=", "rank", 25],
-      ["any", ["!has", "level"],
-        ["==", "level", 0]
-      ]
-    ],
-    "id": "poi-level-3",
-    "layout": {
-      "icon-image": "{class}_11",
-      "text-anchor": "top",
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 9,
-      "text-offset": [0, 0.6],
-      "text-padding": 2,
-      "text-size": 12,
-      "visibility": "visible"
-    },
-    "minzoom": 16,
-    "paint": {
-      "text-color": "#666",
-      "text-halo-blur": 0.5,
-      "text-halo-color": "#ffffff",
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "poi",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "Point"],
-      ["<=", "rank", 24],
-      [">=", "rank", 15],
-      ["any", ["!has", "level"],
-        ["==", "level", 0]
-      ]
-    ],
-    "id": "poi-level-2",
-    "layout": {
-      "icon-image": "{class}_11",
-      "text-anchor": "top",
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 9,
-      "text-offset": [0, 0.6],
-      "text-padding": 2,
-      "text-size": 12,
-      "visibility": "visible"
-    },
-    "minzoom": 15,
-    "paint": {
-      "text-color": "#666",
-      "text-halo-blur": 0.5,
-      "text-halo-color": "#ffffff",
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "poi",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "Point"],
-      ["<=", "rank", 14],
-      ["has", "name"],
-      ["any", ["!has", "level"],
-        ["==", "level", 0]
-      ]
-    ],
-    "id": "poi-level-1",
-    "layout": {
-      "icon-image": "{class}_11",
-      "text-anchor": "top",
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 9,
-      "text-offset": [0, 0.6],
-      "text-padding": 2,
-      "text-size": 12,
-      "visibility": "visible"
-    },
-    "minzoom": 14,
-    "paint": {
-      "text-color": "#666",
-      "text-halo-blur": 0.5,
-      "text-halo-color": "#ffffff",
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "poi",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "Point"],
-      ["has", "name"],
-      ["==", "class", "railway"],
-      ["==", "subclass", "station"]
-    ],
-    "id": "poi-railway",
-    "layout": {
-      "icon-allow-overlap": false,
-      "icon-ignore-placement": false,
-      "icon-image": "{class}_11",
-      "icon-optional": false,
-      "text-allow-overlap": false,
-      "text-anchor": "top",
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-ignore-placement": false,
-      "text-max-width": 9,
-      "text-offset": [0, 0.6],
-      "text-optional": true,
-      "text-padding": 2,
-      "text-size": 12
-    },
-    "minzoom": 13,
-    "paint": {
-      "text-color": "#666",
-      "text-halo-blur": 0.5,
-      "text-halo-color": "#ffffff",
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "poi",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "oneway", 1],
-      ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
-    ],
-    "id": "road_oneway",
-    "layout": {
-      "icon-image": "oneway",
-      "icon-padding": 2,
-      "icon-rotate": 90,
-      "icon-rotation-alignment": "map",
-      "icon-size": {
-        "stops": [
-          [15, 0.5],
-          [19, 1]
-        ]
-      },
-      "symbol-placement": "line",
-      "symbol-spacing": 75
-    },
-    "minzoom": 15,
-    "paint": {
-      "icon-opacity": 0.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "oneway", -1],
-      ["in", "class", "motorway", "trunk", "primary", "secondary", "tertiary", "minor", "service"]
-    ],
-    "id": "road_oneway_opposite",
-    "layout": {
-      "icon-image": "oneway",
-      "icon-padding": 2,
-      "icon-rotate": -90,
-      "icon-rotation-alignment": "map",
-      "icon-size": {
-        "stops": [
-          [15, 0.5],
-          [19, 1]
-        ]
-      },
-      "symbol-placement": "line",
-      "symbol-spacing": 75
-    },
-    "minzoom": 15,
-    "paint": {
-      "icon-opacity": 0.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation",
-    "type": "symbol"
-  }, {
-    "filter": ["==", "class", "path"],
-    "id": "highway-name-path",
-    "layout": {
-      "symbol-placement": "line",
-      "text-field": "{name:latin} {name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-rotation-alignment": "map",
-      "text-size": {
-        "base": 1,
-        "stops": [
-          [13, 12],
-          [14, 13]
-        ]
-      }
-    },
-    "minzoom": 15.5,
-    "paint": {
-      "text-color": "hsl(30, 23%, 62%)",
-      "text-halo-color": "#f8f4f0",
-      "text-halo-width": 0.5
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "$type", "LineString"],
-      ["in", "class", "minor", "service", "track"]
-    ],
-    "id": "highway-name-minor",
-    "layout": {
-      "symbol-placement": "line",
-      "text-field": "{name:latin} {name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-rotation-alignment": "map",
-      "text-size": {
-        "base": 1,
-        "stops": [
-          [13, 12],
-          [14, 13]
-        ]
-      }
-    },
-    "minzoom": 15,
-    "paint": {
-      "text-color": "#765",
-      "text-halo-blur": 0.5,
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation_name",
-    "type": "symbol"
-  }, {
-    "filter": ["in", "class", "primary", "secondary", "tertiary", "trunk"],
-    "id": "highway-name-major",
-    "layout": {
-      "symbol-placement": "line",
-      "text-field": "{name:latin} {name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-rotation-alignment": "map",
-      "text-size": {
-        "base": 1,
-        "stops": [
-          [13, 12],
-          [14, 13]
-        ]
-      }
-    },
-    "minzoom": 12.2,
-    "paint": {
-      "text-color": "#765",
-      "text-halo-blur": 0.5,
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["<=", "ref_length", 6],
-      ["==", "$type", "LineString"],
-      ["!in", "network", "us-interstate", "us-highway", "us-state"]
-    ],
-    "id": "highway-shield",
-    "layout": {
-      "icon-image": "road_{ref_length}",
-      "icon-rotation-alignment": "viewport",
-      "icon-size": 1,
-      "symbol-placement": {
-        "base": 1,
-        "stops": [
-          [10, "point"],
-          [11, "line"]
-        ]
-      },
-      "symbol-spacing": 200,
-      "text-field": "{ref}",
-      "text-font": ["Noto Sans Regular"],
-      "text-rotation-alignment": "viewport",
-      "text-size": 10
-    },
-    "minzoom": 8,
-    "paint": {},
-    "source": "openmaptiles",
-    "source-layer": "transportation_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["<=", "ref_length", 6],
-      ["==", "$type", "LineString"],
-      ["in", "network", "us-interstate"]
-    ],
-    "id": "highway-shield-us-interstate",
-    "layout": {
-      "icon-image": "{network}_{ref_length}",
-      "icon-rotation-alignment": "viewport",
-      "icon-size": 1,
-      "symbol-placement": {
-        "base": 1,
-        "stops": [
-          [7, "point"],
-          [7, "line"],
-          [8, "line"]
-        ]
-      },
-      "symbol-spacing": 200,
-      "text-field": "{ref}",
-      "text-font": ["Noto Sans Regular"],
-      "text-rotation-alignment": "viewport",
-      "text-size": 10
-    },
-    "minzoom": 7,
-    "paint": {
-      "text-color": "rgba(0, 0, 0, 1)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["<=", "ref_length", 6],
-      ["==", "$type", "LineString"],
-      ["in", "network", "us-highway", "us-state"]
-    ],
-    "id": "highway-shield-us-other",
-    "layout": {
-      "icon-image": "{network}_{ref_length}",
-      "icon-rotation-alignment": "viewport",
-      "icon-size": 1,
-      "symbol-placement": {
-        "base": 1,
-        "stops": [
-          [10, "point"],
-          [11, "line"]
-        ]
-      },
-      "symbol-spacing": 200,
-      "text-field": "{ref}",
-      "text-font": ["Noto Sans Regular"],
-      "text-rotation-alignment": "viewport",
-      "text-size": 10
-    },
-    "minzoom": 9,
-    "paint": {
-      "text-color": "rgba(0, 0, 0, 1)"
-    },
-    "source": "openmaptiles",
-    "source-layer": "transportation_name",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["has", "iata"]],
-    "id": "airport-label-major",
-    "layout": {
-      "icon-image": "airport_11",
-      "icon-size": 1,
-      "text-anchor": "top",
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 9,
-      "text-offset": [0, 0.6],
-      "text-optional": true,
-      "text-padding": 2,
-      "text-size": 12,
-      "visibility": "visible"
-    },
-    "minzoom": 10,
-    "paint": {
-      "text-color": "#666",
-      "text-halo-blur": 0.5,
-      "text-halo-color": "#ffffff",
-      "text-halo-width": 1
-    },
-    "source": "openmaptiles",
-    "source-layer": "aerodrome_label",
-    "type": "symbol"
-  }, {
-    "filter": ["!in", "class", "city", "town", "village", "country", "continent"],
-    "id": "place-other",
-    "layout": {
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Bold"],
-      "text-letter-spacing": 0.1,
-      "text-max-width": 9,
-      "text-size": {
-        "base": 1.2,
-        "stops": [
-          [12, 10],
-          [15, 14]
-        ]
-      },
-      "text-transform": "uppercase",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#633",
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 1.2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["==", "class", "village"],
-    "id": "place-village",
-    "layout": {
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 8,
-      "text-size": {
-        "base": 1.2,
-        "stops": [
-          [10, 12],
-          [15, 22]
-        ]
-      },
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#333",
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 1.2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["==", "class", "town"],
-    "id": "place-town",
-    "layout": {
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 8,
-      "text-size": {
-        "base": 1.2,
-        "stops": [
-          [10, 14],
-          [15, 24]
-        ]
-      },
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#333",
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 1.2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["!=", "capital", 2],
-      ["==", "class", "city"]
-    ],
-    "id": "place-city",
-    "layout": {
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 8,
-      "text-size": {
-        "base": 1.2,
-        "stops": [
-          [7, 14],
-          [11, 24]
-        ]
-      },
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#333",
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 1.2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "capital", 2],
-      ["==", "class", "city"]
-    ],
-    "id": "place-city-capital",
-    "layout": {
-      "icon-image": "star_11",
-      "icon-size": 0.8,
-      "text-anchor": "left",
-      "text-field": "{name:latin}\n{name:nonlatin}",
-      "text-font": ["Noto Sans Regular"],
-      "text-max-width": 8,
-      "text-offset": [0.4, 0],
-      "text-size": {
-        "base": 1.2,
-        "stops": [
-          [7, 14],
-          [11, 24]
-        ]
-      },
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#333",
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 1.2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "class", "country"],
-      [">=", "rank", 3],
-      ["!has", "iso_a2"]
-    ],
-    "id": "place-country-other",
-    "layout": {
-      "text-field": "{name:latin}",
-      "text-font": ["Noto Sans Italic"],
-      "text-max-width": 6.25,
-      "text-size": {
-        "stops": [
-          [3, 11],
-          [7, 17]
-        ]
-      },
-      "text-transform": "uppercase",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#334",
-      "text-halo-blur": 1,
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "class", "country"],
-      [">=", "rank", 3],
-      ["has", "iso_a2"]
-    ],
-    "id": "place-country-3",
-    "layout": {
-      "text-field": "{name:latin}",
-      "text-font": ["Noto Sans Bold"],
-      "text-max-width": 6.25,
-      "text-size": {
-        "stops": [
-          [3, 11],
-          [7, 17]
-        ]
-      },
-      "text-transform": "uppercase",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#334",
-      "text-halo-blur": 1,
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "class", "country"],
-      ["==", "rank", 2],
-      ["has", "iso_a2"]
-    ],
-    "id": "place-country-2",
-    "layout": {
-      "text-field": "{name:latin}",
-      "text-font": ["Noto Sans Bold"],
-      "text-max-width": 6.25,
-      "text-size": {
-        "stops": [
-          [2, 11],
-          [5, 17]
-        ]
-      },
-      "text-transform": "uppercase",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#334",
-      "text-halo-blur": 1,
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["all", ["==", "class", "country"],
-      ["==", "rank", 1],
-      ["has", "iso_a2"]
-    ],
-    "id": "place-country-1",
-    "layout": {
-      "text-field": "{name:latin}",
-      "text-font": ["Noto Sans Bold"],
-      "text-max-width": 6.25,
-      "text-size": {
-        "stops": [
-          [1, 11],
-          [4, 17]
-        ]
-      },
-      "text-transform": "uppercase",
-      "visibility": "visible"
-    },
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#334",
-      "text-halo-blur": 1,
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }, {
-    "filter": ["==", "class", "continent"],
-    "id": "place-continent",
-    "layout": {
-      "text-field": "{name:latin}",
-      "text-font": ["Noto Sans Bold"],
-      "text-max-width": 6.25,
-      "text-size": 14,
-      "text-transform": "uppercase",
-      "visibility": "visible"
-    },
-    "maxzoom": 1,
-    "metadata": {
-      "mapbox:group": "1444849242106.713"
-    },
-    "paint": {
-      "text-color": "#334",
-      "text-halo-blur": 1,
-      "text-halo-color": "rgba(255,255,255,0.8)",
-      "text-halo-width": 2
-    },
-    "source": "openmaptiles",
-    "source-layer": "place",
-    "type": "symbol"
-  }],
+  "version": 8,
+  "name": "Bright",
   "metadata": {
     "mapbox:autocomposite": false,
     "mapbox:groups": {
-      "1444849242106.713": {
-        "collapsed": false,
-        "name": "Places"
-      },
-      "1444849334699.1902": {
-        "collapsed": true,
-        "name": "Bridges"
-      },
-      "1444849345966.4436": {
-        "collapsed": false,
-        "name": "Roads"
-      },
-      "1444849354174.1904": {
-        "collapsed": true,
-        "name": "Tunnels"
-      },
-      "1444849364238.8171": {
-        "collapsed": false,
-        "name": "Buildings"
-      },
-      "1444849382550.77": {
-        "collapsed": false,
-        "name": "Water"
-      },
-      "1444849388993.3071": {
-        "collapsed": false,
-        "name": "Land"
-      }
+      "1444849242106.713": {"collapsed": false, "name": "Places"},
+      "1444849334699.1902": {"collapsed": true, "name": "Bridges"},
+      "1444849345966.4436": {"collapsed": false, "name": "Roads"},
+      "1444849354174.1904": {"collapsed": true, "name": "Tunnels"},
+      "1444849364238.8171": {"collapsed": false, "name": "Buildings"},
+      "1444849382550.77": {"collapsed": false, "name": "Water"},
+      "1444849388993.3071": {"collapsed": false, "name": "Land"}
     },
     "mapbox:type": "template",
     "openmaptiles:mapbox:owner": "openmaptiles",
     "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
     "openmaptiles:version": "3.x"
   },
-  "name": "Bright",
+  "center": [0, 0],
+  "zoom": 1,
+  "bearing": 0,
+  "pitch": 0,
   "sources": {
     "openmaptiles": {
       "type": "vector",
@@ -2944,9 +28,2260 @@
     }
   },
   "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
-  "version": 8,
-  "center": [0, 0],
-  "zoom": 1,
-  "bearing": 0,
-  "pitch": 0
+  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key={key}",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {"background-color": "#f8f4f0"}
+    },
+    {
+      "id": "landcover-glacier",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["==", "subclass", "glacier"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "#fff",
+        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
+      }
+    },
+    {
+      "id": "landuse-residential",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        ["in", "class", "residential", "suburb", "neighbourhood"]
+      ],
+      "paint": {
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [12, "hsla(30, 19%, 90%, 0.4)"],
+            [16, "hsla(30, 19%, 90%, 0.2)"]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse-commercial",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["==", "class", "commercial"]
+      ],
+      "paint": {"fill-color": "hsla(0, 60%, 87%, 0.23)"}
+    },
+    {
+      "id": "landuse-industrial",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["==", "class", "industrial"]
+      ],
+      "paint": {"fill-color": "hsla(49, 100%, 88%, 0.34)"}
+    },
+    {
+      "id": "landuse-cemetery",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "cemetery"],
+      "paint": {"fill-color": "#e0e4dd"}
+    },
+    {
+      "id": "landuse-hospital",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "hospital"],
+      "paint": {"fill-color": "#fde"}
+    },
+    {
+      "id": "landuse-school",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "school"],
+      "paint": {"fill-color": "#f0e8f8"}
+    },
+    {
+      "id": "landuse-railway",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "railway"],
+      "paint": {"fill-color": "hsla(30, 19%, 90%, 0.4)"}
+    },
+    {
+      "id": "landcover-wood",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["==", "class", "wood"],
+      "paint": {
+        "fill-antialias": {"base": 1, "stops": [[0, false], [9, true]]},
+        "fill-color": "#6a4",
+        "fill-opacity": 0.1,
+        "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
+      }
+    },
+    {
+      "id": "landcover-grass",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["==", "class", "grass"],
+      "paint": {"fill-color": "#d8e8c8", "fill-opacity": 1}
+    },
+    {
+      "id": "landcover-grass-park",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "filter": ["==", "class", "public_park"],
+      "paint": {"fill-color": "#d8e8c8", "fill-opacity": 0.8}
+    },
+    {
+      "id": "waterway_tunnel",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["in", "class", "river", "stream", "canal"],
+        ["==", "brunnel", "tunnel"]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [2, 4],
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
+      }
+    },
+    {
+      "id": "waterway-other",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["!in", "class", "canal", "river", "stream"],
+        ["==", "intermittent", 0]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 2]]}
+      }
+    },
+    {
+      "id": "waterway-other-intermittent",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["!in", "class", "canal", "river", "stream"],
+        ["==", "intermittent", 1]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 2]]},
+        "line-dasharray": [4, 3]
+      }
+    },
+    {
+      "id": "waterway-stream-canal",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["in", "class", "canal", "stream"],
+        ["!=", "brunnel", "tunnel"],
+        ["==", "intermittent", 0]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
+      }
+    },
+    {
+      "id": "waterway-stream-canal-intermittent",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["in", "class", "canal", "stream"],
+        ["!=", "brunnel", "tunnel"],
+        ["==", "intermittent", 1]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]},
+        "line-dasharray": [4, 3]
+      }
+    },
+    {
+      "id": "waterway-river",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["==", "class", "river"],
+        ["!=", "brunnel", "tunnel"],
+        ["==", "intermittent", 0]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.2, "stops": [[10, 0.8], [20, 6]]}
+      }
+    },
+    {
+      "id": "waterway-river-intermittent",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["==", "class", "river"],
+        ["!=", "brunnel", "tunnel"],
+        ["==", "intermittent", 1]
+      ],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.2, "stops": [[10, 0.8], [20, 6]]},
+        "line-dasharray": [3, 2.5]
+      }
+    },
+    {
+      "id": "water-offset",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "maxzoom": 8,
+      "filter": ["==", "$type", "Polygon"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "#a0c8f0",
+        "fill-opacity": 1,
+        "fill-translate": {"base": 1, "stops": [[6, [2, 0]], [8, [0, 0]]]}
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": ["all", ["!=", "intermittent", 1]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "hsl(210, 67%, 85%)"}
+    },
+    {
+      "id": "water-intermittent",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": ["all", ["==", "intermittent", 1]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "hsl(210, 67%, 85%)", "fill-opacity": 0.7}
+    },
+    {
+      "id": "water-pattern",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": ["all"],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-pattern": "wave", "fill-translate": [0, 2.5]}
+    },
+    {
+      "id": "landcover-ice-shelf",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["==", "subclass", "ice_shelf"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "#fff",
+        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
+      }
+    },
+    {
+      "id": "landcover-sand",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849382550.77"},
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["all", ["==", "class", "sand"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(245, 238, 188, 1)", "fill-opacity": 1}
+    },
+    {
+      "id": "building",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849364238.8171"},
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": {"base": 1, "stops": [[15.5, "#f2eae2"], [16, "#dfdbd7"]]}
+      }
+    },
+    {
+      "id": "building-top",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849364238.8171"},
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "#f2eae2",
+        "fill-opacity": {"base": 1, "stops": [[13, 0], [16, 1]]},
+        "fill-outline-color": "#dfdbd7",
+        "fill-translate": {"base": 1, "stops": [[14, [0, 0]], [16, [-2, -2]]]}
+      }
+    },
+    {
+      "id": "tunnel-service-track-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-dasharray": [0.5, 0.25],
+        "line-width": {"base": 1.2, "stops": [[15, 1], [16, 4], [20, 11]]}
+      }
+    },
+    {
+      "id": "tunnel-minor-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "minor"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+      }
+    },
+    {
+      "id": "tunnel-trunk-primary-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "tunnel-motorway-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {"line-join": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-dasharray": [0.5, 0.25],
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "tunnel-path",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "path"]]
+      ],
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [1.5, 0.75],
+        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]}
+      }
+    },
+    {
+      "id": "tunnel-service-track",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
+      }
+    },
+    {
+      "id": "tunnel-minor",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "minor_road"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
+      }
+    },
+    {
+      "id": "tunnel-trunk-primary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "tunnel-motorway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {"line-join": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "#ffdaa6",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "tunnel-railway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "rail"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [2, 2],
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "ferry",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["in", "class", "ferry"]],
+      "layout": {"line-join": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "rgba(108, 159, 182, 1)",
+        "line-dasharray": [2, 2],
+        "line-width": 1.1
+      }
+    },
+    {
+      "id": "aeroway-taxiway-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 12,
+      "filter": ["all", ["in", "class", "taxiway"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-opacity": 1,
+        "line-width": {"base": 1.5, "stops": [[11, 2], [17, 12]]}
+      }
+    },
+    {
+      "id": "aeroway-runway-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 12,
+      "filter": ["all", ["in", "class", "runway"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-opacity": 1,
+        "line-width": {"base": 1.5, "stops": [[11, 5], [17, 55]]}
+      }
+    },
+    {
+      "id": "aeroway-area",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["in", "class", "runway", "taxiway"]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(255, 255, 255, 1)",
+        "fill-opacity": {"base": 1, "stops": [[13, 0], [14, 1]]}
+      }
+    },
+    {
+      "id": "aeroway-taxiway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        ["in", "class", "taxiway"],
+        ["==", "$type", "LineString"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": {"base": 1, "stops": [[11, 0], [12, 1]]},
+        "line-width": {"base": 1.5, "stops": [[11, 1], [17, 10]]}
+      }
+    },
+    {
+      "id": "aeroway-runway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        ["in", "class", "runway"],
+        ["==", "$type", "LineString"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": {"base": 1, "stops": [[11, 0], [12, 1]]},
+        "line-width": {"base": 1.5, "stops": [[11, 4], [17, 50]]}
+      }
+    },
+    {
+      "id": "road_area_pier",
+      "type": "fill",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "pier"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-antialias": true, "fill-color": "#f8f4f0"}
+    },
+    {
+      "id": "road_pier",
+      "type": "line",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "pier"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {"base": 1.2, "stops": [[15, 1], [17, 4]]}
+      }
+    },
+    {
+      "id": "highway-area",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "$type", "Polygon"], ["!in", "class", "pier"]],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsla(0, 0%, 89%, 0.56)",
+        "fill-opacity": 0.9,
+        "fill-outline-color": "#cfcdca"
+      }
+    },
+    {
+      "id": "highway-motorway-link-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway_link"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "highway-link-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "highway-minor-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!=", "brunnel", "tunnel"],
+          ["in", "class", "minor", "service", "track"]
+        ]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "highway-secondary-tertiary-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+      }
+    },
+    {
+      "id": "highway-primary-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "primary"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {"stops": [[7, 0], [8, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[7, 0], [8, 0.6], [9, 1.5], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "highway-trunk-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "trunk"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {"stops": [[5, 0], [6, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0], [6, 0.6], [7, 1.5], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "highway-motorway-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {"stops": [[4, 0], [5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[4, 0], [5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "highway-path",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["!in", "brunnel", "bridge", "tunnel"], ["==", "class", "path"]]
+      ],
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [1.5, 0.75],
+        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]}
+      }
+    },
+    {
+      "id": "highway-motorway-link",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway_link"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "highway-link",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "highway-minor",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!=", "brunnel", "tunnel"],
+          ["in", "class", "minor", "service", "track"]
+        ]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+      }
+    },
+    {
+      "id": "highway-secondary-tertiary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
+      }
+    },
+    {
+      "id": "highway-primary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["in", "class", "primary"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[8.5, 0], [9, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "highway-trunk",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["in", "class", "trunk"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "highway-motorway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["==", "class", "motorway"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "railway-transit",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.77)",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [20, 1]]}
+      }
+    },
+    {
+      "id": "railway-transit-hatching",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.68)",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 2], [20, 6]]}
+      }
+    },
+    {
+      "id": "railway-service",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "rail"], ["has", "service"]]
+      ],
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.77)",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [20, 1]]}
+      }
+    },
+    {
+      "id": "railway-service-hatching",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "rail"], ["has", "service"]]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.68)",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 2], [20, 6]]}
+      }
+    },
+    {
+      "id": "railway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!has", "service"],
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["==", "class", "rail"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "railway-hatching",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!has", "service"],
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["==", "class", "rail"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "bridge-motorway-link-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "motorway_link"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "bridge-link-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 28]]}
+      }
+    },
+    {
+      "id": "bridge-trunk-primary-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "hsl(28, 76%, 67%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 26]]
+        }
+      }
+    },
+    {
+      "id": "bridge-motorway-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "bridge-path-casing",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "bridge"], ["==", "class", "path"]]
+      ],
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge-path",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "bridge"], ["==", "class", "path"]]
+      ],
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [1.5, 0.75],
+        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]}
+      }
+    },
+    {
+      "id": "bridge-motorway-link",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "motorway_link"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "bridge-link",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 20]]}
+      }
+    },
+    {
+      "id": "bridge-trunk-primary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge-motorway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge-railway",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "bridge"], ["==", "class", "rail"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "bridge-railway-hatching",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "bridge"], ["==", "class", "rail"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "cablecar",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": ["==", "class", "cable_car"],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-width": {"base": 1, "stops": [[11, 1], [19, 2.5]]}
+      }
+    },
+    {
+      "id": "cablecar-dash",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": ["==", "class", "cable_car"],
+      "layout": {"line-cap": "round", "visibility": "visible"},
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-dasharray": [2, 3],
+        "line-width": {"base": 1, "stops": [[11, 3], [19, 5.5]]}
+      }
+    },
+    {
+      "id": "boundary-land-level-4",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": [
+        "all",
+        [">=", "admin_level", 4],
+        ["<=", "admin_level", 8],
+        ["!=", "maritime", 1]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#9e9cab",
+        "line-dasharray": [3, 1, 1, 1],
+        "line-width": {"base": 1.4, "stops": [[4, 0.4], [5, 1], [12, 3]]}
+      }
+    },
+    {
+      "id": "boundary-land-level-2",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": [
+        "all",
+        ["==", "admin_level", 2],
+        ["!=", "maritime", 1],
+        ["!=", "disputed", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "hsl(248, 7%, 66%)",
+        "line-width": {
+          "base": 1,
+          "stops": [[0, 0.6], [4, 1.4], [5, 2], [12, 8]]
+        }
+      }
+    },
+    {
+      "id": "boundary-land-disputed",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": ["all", ["!=", "maritime", 1], ["==", "disputed", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "hsl(248, 7%, 70%)",
+        "line-dasharray": [1, 3],
+        "line-width": {
+          "base": 1,
+          "stops": [[0, 0.6], [4, 1.4], [5, 2], [12, 8]]
+        }
+      }
+    },
+    {
+      "id": "boundary-water",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": ["all", ["in", "admin_level", 2, 4], ["==", "maritime", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "rgba(154, 189, 214, 1)",
+        "line-opacity": {"stops": [[6, 0.6], [10, 1]]},
+        "line-width": {
+          "base": 1,
+          "stops": [[0, 0.6], [4, 1.4], [5, 2], [12, 8]]
+        }
+      }
+    },
+    {
+      "id": "waterway-name",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "minzoom": 13,
+      "filter": ["all", ["==", "$type", "LineString"], ["has", "name"]],
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": ["Noto Sans Italic"],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water-name-lakeline",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": ["==", "$type", "LineString"],
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Italic"],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water-name-ocean",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "ocean"]],
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Italic"],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "water-name-other",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": ["all", ["==", "$type", "Point"], ["!in", "class", "ocean"]],
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Italic"],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": {"stops": [[0, 10], [6, 14]]},
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "poi-level-3",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [">=", "rank", 25],
+        ["any", ["!has", "level"], ["==", "level", 0]]
+      ],
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-level-2",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 24],
+        [">=", "rank", 15],
+        ["any", ["!has", "level"], ["==", "level", 0]]
+      ],
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-level-1",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 14],
+        ["has", "name"],
+        ["any", ["!has", "level"], ["==", "level", 0]]
+      ],
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-railway",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["has", "name"],
+        ["==", "class", "railway"],
+        ["==", "subclass", "station"]
+      ],
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-ignore-placement": false,
+        "icon-image": "{class}_11",
+        "icon-optional": false,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-ignore-placement": false,
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "road_oneway",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "oneway", 1],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ],
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": 90,
+        "icon-rotation-alignment": "map",
+        "icon-size": {"stops": [[15, 0.5], [19, 1]]},
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "paint": {"icon-opacity": 0.5}
+    },
+    {
+      "id": "road_oneway_opposite",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "oneway", -1],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ],
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": -90,
+        "icon-rotation-alignment": "map",
+        "icon-size": {"stops": [[15, 0.5], [19, 1]]},
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "paint": {"icon-opacity": 0.5}
+    },
+    {
+      "id": "highway-name-path",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 15.5,
+      "filter": ["==", "class", "path"],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "map",
+        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]}
+      },
+      "paint": {
+        "text-color": "hsl(30, 23%, 62%)",
+        "text-halo-color": "#f8f4f0",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "highway-name-minor",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "minor", "service", "track"]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "map",
+        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]}
+      },
+      "paint": {
+        "text-color": "#765",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "highway-name-major",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 12.2,
+      "filter": ["in", "class", "primary", "secondary", "tertiary", "trunk"],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "map",
+        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]}
+      },
+      "paint": {
+        "text-color": "#765",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "highway-shield",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        ["<=", "ref_length", 6],
+        ["==", "$type", "LineString"],
+        ["!in", "network", "us-interstate", "us-highway", "us-state"]
+      ],
+      "layout": {
+        "icon-image": "road_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {"base": 1, "stops": [[10, "point"], [11, "line"]]},
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      },
+      "paint": {}
+    },
+    {
+      "id": "highway-shield-us-interstate",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["<=", "ref_length", 6],
+        ["==", "$type", "LineString"],
+        ["in", "network", "us-interstate"]
+      ],
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [[7, "point"], [7, "line"], [8, "line"]]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      },
+      "paint": {"text-color": "rgba(0, 0, 0, 1)"}
+    },
+    {
+      "id": "highway-shield-us-other",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 9,
+      "filter": [
+        "all",
+        ["<=", "ref_length", 6],
+        ["==", "$type", "LineString"],
+        ["in", "network", "us-highway", "us-state"]
+      ],
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {"base": 1, "stops": [[10, "point"], [11, "line"]]},
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10
+      },
+      "paint": {"text-color": "rgba(0, 0, 0, 1)"}
+    },
+    {
+      "id": "airport-label-major",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "aerodrome_label",
+      "minzoom": 10,
+      "filter": ["all", ["has", "iata"]],
+      "layout": {
+        "icon-image": "airport_11",
+        "icon-size": 1,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "place-other",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "!in",
+        "class",
+        "city",
+        "town",
+        "village",
+        "country",
+        "continent"
+      ],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Bold"],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-size": {"base": 1.2, "stops": [[12, 10], [15, 14]]},
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#633",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-village",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["==", "class", "village"],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-size": {"base": 1.2, "stops": [[10, 12], [15, 22]]},
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-town",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["==", "class", "town"],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-size": {"base": 1.2, "stops": [[10, 14], [15, 24]]},
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-city",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", ["!=", "capital", 2], ["==", "class", "city"]],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-size": {"base": 1.2, "stops": [[7, 14], [11, 24]]},
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-city-capital",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", ["==", "capital", 2], ["==", "class", "city"]],
+      "layout": {
+        "icon-image": "star_11",
+        "icon-size": 0.8,
+        "text-anchor": "left",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-offset": [0.4, 0],
+        "text-size": {"base": 1.2, "stops": [[7, 14], [11, 24]]},
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-country-other",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        ["==", "class", "country"],
+        [">=", "rank", 3],
+        ["!has", "iso_a2"]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Italic"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[3, 11], [7, 17]]},
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-country-3",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        ["==", "class", "country"],
+        [">=", "rank", 3],
+        ["has", "iso_a2"]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Bold"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[3, 11], [7, 17]]},
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-country-2",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        ["==", "class", "country"],
+        ["==", "rank", 2],
+        ["has", "iso_a2"]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Bold"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[2, 11], [5, 17]]},
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-country-1",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        ["==", "class", "country"],
+        ["==", "rank", 1],
+        ["has", "iso_a2"]
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Bold"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[1, 11], [4, 17]]},
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place-continent",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 1,
+      "filter": ["==", "class", "continent"],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Bold"],
+        "text-max-width": 6.25,
+        "text-size": 14,
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
+      }
+    }
+  ],
+  "id": "bright"
 }


### PR DESCRIPTION
Format style with [gl-style-format](https://www.npmjs.com/package/@mapbox/mapbox-gl-style-spec#gl-style-format) to use standard indentation and sorted object keys for better readability and unification.

Fixes #24