### PR TITLE
Use dash for all tunnel casing

### DIFF
--- a/style.json
+++ b/style.json
@@ -414,7 +414,8 @@
         "line-width": {
           "base": 1.2,
           "stops": [[12, 0.5], [13, 1], [14, 4], [20, 15]]
-        }
+        },
+        "line-dasharray": [0.5, 0.25]
       }
     },
     {
@@ -432,7 +433,8 @@
       "paint": {
         "line-color": "#e9ac77",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]},
+        "line-dasharray": [0.5, 0.25]
       }
     },
     {


### PR DESCRIPTION
Casing are dash for layers motorway, trunk-primary and service-track but not for secondary-tertiary and minor.

Use the same dash array also for secondary-tertiary and minor tunnel layers.