### PR TITLE
Style for OMT 3.11 - garages+dam, water brunnel

### DIFF
--- a/style.json
+++ b/style.json
@@ -58,6 +58,7 @@
         "all",
         ["in", "class", "residential", "suburb", "neighbourhood"]
       ],
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": {
           "base": 1,
@@ -79,19 +80,20 @@
         ["==", "$type", "Polygon"],
         ["==", "class", "commercial"]
       ],
+      "layout": {"visibility": "visible"},
       "paint": {"fill-color": "hsla(0, 60%, 87%, 0.23)"}
     },
     {
       "id": "landuse-industrial",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": [
         "all",
         ["==", "$type", "Polygon"],
-        ["==", "class", "industrial"]
+        ["in", "class", "industrial", "garages", "dam"]
       ],
+      "layout": {"visibility": "visible"},
       "paint": {"fill-color": "hsla(49, 100%, 88%, 0.34)"}
     },
     {
@@ -128,6 +130,7 @@
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": ["==", "class", "railway"],
+      "layout": {"visibility": "visible"},
       "paint": {"fill-color": "hsla(30, 19%, 90%, 0.4)"}
     },
     {
@@ -211,8 +214,8 @@
       "layout": {"line-cap": "round", "visibility": "visible"},
       "paint": {
         "line-color": "#a0c8f0",
-        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 2]]},
-        "line-dasharray": [4, 3]
+        "line-dasharray": [4, 3],
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 2]]}
       }
     },
     {
@@ -248,8 +251,8 @@
       "layout": {"line-cap": "round", "visibility": "visible"},
       "paint": {
         "line-color": "#a0c8f0",
-        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]},
-        "line-dasharray": [4, 3]
+        "line-dasharray": [4, 3],
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
       }
     },
     {
@@ -285,8 +288,8 @@
       "layout": {"line-cap": "round", "visibility": "visible"},
       "paint": {
         "line-color": "#a0c8f0",
-        "line-width": {"base": 1.2, "stops": [[10, 0.8], [20, 6]]},
-        "line-dasharray": [3, 2.5]
+        "line-dasharray": [3, 2.5],
+        "line-width": {"base": 1.2, "stops": [[10, 0.8], [20, 6]]}
       }
     },
     {
@@ -310,7 +313,7 @@
       "metadata": {"mapbox:group": "1444849382550.77"},
       "source": "openmaptiles",
       "source-layer": "water",
-      "filter": ["all", ["!=", "intermittent", 1]],
+      "filter": ["all", ["!=", "intermittent", 1], ["!=", "brunnel", "tunnel"]],
       "layout": {"visibility": "visible"},
       "paint": {"fill-color": "hsl(210, 67%, 85%)"}
     },
@@ -1527,7 +1530,7 @@
         ["<=", "admin_level", 8],
         ["!=", "maritime", 1]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
         "line-color": "#9e9cab",
         "line-dasharray": [3, 1, 1, 1],
@@ -1545,7 +1548,11 @@
         ["!=", "maritime", 1],
         ["!=", "disputed", 1]
       ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "hsl(248, 7%, 66%)",
         "line-width": {
@@ -1560,7 +1567,11 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "filter": ["all", ["!=", "maritime", 1], ["==", "disputed", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "hsl(248, 7%, 70%)",
         "line-dasharray": [1, 3],
@@ -1575,8 +1586,13 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
+      "minzoom": 4,
       "filter": ["all", ["in", "admin_level", 2, 4], ["==", "maritime", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(154, 189, 214, 1)",
         "line-opacity": {"stops": [[6, 0.6], [10, 1]]},


### PR DESCRIPTION
Formatted via https://www.npmjs.com/package/@mapbox/mapbox-gl-style-spec#gl-style-format as agreed in https://github.com/openmaptiles/osm-bright-gl-style/pull/26.