### PR TITLE
Fix secondary-tertiary bridge width

### DIFF
--- a/style.json
+++ b/style.json
@@ -1280,7 +1280,10 @@
       "paint": {
         "line-color": "#e9ac77",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 28]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [7, 0.6], [8, 1.5], [20, 21]]
+        }
       }
     },
     {
@@ -1460,7 +1463,7 @@
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#fea",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 20]]}
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
       }
     },
     {


### PR DESCRIPTION
All the transportation bridges have the same width as other part of the road, except the secondary-tertiary bridge layer.

In order: motorway / trunk-primary / secondary-tertiary, at same scale.
![imagen](https://user-images.githubusercontent.com/1785486/79685075-2ba06c00-8236-11ea-9571-58af99ff88eb.png)
Note: due to missing extra casing to motorway bridge we can not distinguish the bridge itself, see PR #34.

Keep the same width for the bridge road as the standard road.

![imagen](https://user-images.githubusercontent.com/1785486/79684978-9d2bea80-8235-11ea-9f12-64d42a7dbfab.png)
![imagen](https://user-images.githubusercontent.com/1785486/79684981-a321cb80-8235-11ea-8742-000bc9596cb5.png)