### PR TITLE
Split state labels out into new layer

### DIFF
--- a/style.json
+++ b/style.json
@@ -2060,13 +2060,14 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "filter": [
-        "!in",
-        "class",
-        "city",
-        "town",
-        "village",
-        "country",
-        "continent"
+          "!in",
+          "class",
+          "city",
+          "town",
+          "village",
+          "state",
+          "country",
+          "continent"
       ],
       "layout": {
         "text-field": "{name:latin}\n{name:nonlatin}",
@@ -2163,6 +2164,33 @@
       },
       "paint": {
         "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place-state",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849242106.713"},
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 2,
+      "filter": [
+        "in",
+        "class",
+        "state"
+      ],
+      "layout": {
+        "text-field": "{name:latin}",
+        "text-font": ["Noto Sans Bold"],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-size": {"base": 1.2, "stops": [[12, 10], [15, 14]]},
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#633",
         "text-halo-color": "rgba(255,255,255,0.8)",
         "text-halo-width": 1.2
       }

--- a/style.json
+++ b/style.json
@@ -2174,7 +2174,6 @@
       "metadata": {"mapbox:group": "1444849242106.713"},
       "source": "openmaptiles",
       "source-layer": "place",
-      "minzoom": 2,
       "filter": [
         "in",
         "class",

--- a/style.json
+++ b/style.json
@@ -2060,14 +2060,14 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "filter": [
-          "!in",
-          "class",
-          "city",
-          "town",
-          "village",
-          "state",
-          "country",
-          "continent"
+        "!in",
+        "class",
+        "city",
+        "town",
+        "village",
+        "state",
+        "country",
+        "continent"
       ],
       "layout": {
         "text-field": "{name:latin}\n{name:nonlatin}",


### PR DESCRIPTION
This PR complements the [open PR in OpenMapTiles](https://github.com/openmaptiles/openmaptiles/pull/969) to increase the number of state labels rendered at low zoom levels.

In this style in particular the state labels are part of the `place-other` layer. I included `state` in the filter, and duplicated the layer definition up in the list to give them more relevancy, between country and city layers. The rest of the definition is the same, so no visual distinction between state labels and small features below the city level.