### PR TITLE
Fix incomplete state borders

### DIFF
--- a/style.json
+++ b/style.json
@@ -1556,7 +1556,7 @@
       "source-layer": "boundary",
       "filter": [
         "all",
-        [">=", "admin_level", 4],
+        [">=", "admin_level", 3],
         ["<=", "admin_level", 8],
         ["!=", "maritime", 1]
       ],


### PR DESCRIPTION
Current state borders are not complete because the filter of the `boundary-land-level-4` layer is not allowing `admin_level=3` lines. You can see this very clearly in the Turkey or Brazil borders

https://www.maptiler.com/maps/#bright//vector/5.4/33.761/37.419

![image](https://user-images.githubusercontent.com/188264/91884939-37417c00-ec87-11ea-8add-4c68001dff8d.png)

Lowering this filter to `3` fixes this situation.