### PR TITLE
Add style for steps

### DIFF
--- a/style.json
+++ b/style.json
@@ -530,6 +530,52 @@
       }
     },
     {
+      "id": "tunnel-path-steps-casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "path"],
+        ["==", "subclass", "steps"]
+      ],
+      "layout": {"line-cap": "butt", "line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 2], [20, 9.25]]
+        },
+        "line-dasharray": [0.5, 0.25]
+      }
+    },
+    {
+      "id": "tunnel-path-steps",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "path"],
+        ["==", "subclass", "steps"]
+      ],
+      "layout": {"line-join": "bevel", "line-cap": "butt"},
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[13.5, 0], [14, 1.25], [20, 5.75]]
+        },
+        "line-dasharray": [0.5, 0.25]
+      }
+    },
+    {
       "id": "tunnel-path",
       "type": "line",
       "metadata": {"mapbox:group": "1444849354174.1904"},
@@ -539,7 +585,8 @@
         "all",
         ["==", "$type", "LineString"],
         ["==", "brunnel", "tunnel"],
-        ["==", "class", "path"]
+        ["==", "class", "path"],
+        ["!=", "subclass", "steps"]
       ],
       "paint": {
         "line-color": "#cba",
@@ -841,6 +888,28 @@
       }
     },
     {
+      "id": "highway-path-steps-casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "path"],
+        ["in", "subclass", "steps"]
+      ],
+      "layout": {"line-cap": "butt", "line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 2], [20, 9.25]]
+        }
+      }
+    },
+    {
       "id": "highway-motorway-link-casing",
       "type": "line",
       "metadata": {"mapbox:group": "1444849345966.4436"},
@@ -1026,12 +1095,36 @@
         "all",
         ["==", "$type", "LineString"],
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "path"]
+        ["==", "class", "path"],
+        ["!=", "subclass", "steps"]
       ],
       "paint": {
         "line-color": "#cba",
         "line-dasharray": [1.5, 0.75],
         "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]}
+      }
+    },
+    {
+      "id": "highway-path-steps",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "path"],
+        ["==", "subclass", "steps"]
+      ],
+      "layout": {"line-join": "bevel", "line-cap": "butt"},
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[13.5, 0], [14, 1.25], [20, 5.75]]
+        },
+        "line-dasharray": [0.5, 0.25]
       }
     },
     {
@@ -1446,8 +1539,31 @@
         ["==", "class", "path"]
       ],
       "paint": {
-        "line-color": "#f8f4f0",
+        "line-color": "#cfcdca",
         "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge-path-steps",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "bridge"],
+        ["==", "class", "path"],
+        ["==", "subclass", "steps"]
+      ],
+      "layout": {"line-join": "round", "line-cap": "butt"},
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [[13.5, 0], [14, 1.25], [20, 5.75]]
+        },
+        "line-dasharray": [0.5, 0.25]
       }
     },
     {
@@ -1460,7 +1576,8 @@
         "all",
         ["==", "$type", "LineString"],
         ["==", "brunnel", "bridge"],
-        ["==", "class", "path"]
+        ["==", "class", "path"],
+        ["!=", "subclass", "steps"]
       ],
       "paint": {
         "line-color": "#cba",


### PR DESCRIPTION
Add layer to distinguish steps from standard paths.

Also change the colour of bridge path (stops or not) from background colour, to bridge colour.

Before / After #18.75/43.7356799/7.4176292

With steps and bridge path

![image](https://user-images.githubusercontent.com/1785486/231194589-12cd9c4d-47fa-445b-9365-b0803b78556e.png)


Before / After #20.06/43.7307424/7.4263301

With steps, bridge steps and tunnel steps

![image](https://user-images.githubusercontent.com/1785486/231194626-2d39eae1-335e-4643-931a-3c68b274930b.png)
