### PR TITLE
Add a building-name label layer

### DIFF
--- a/style.json
+++ b/style.json
@@ -2572,6 +2572,29 @@
         "text-halo-color": "rgba(255,255,255,0.8)",
         "text-halo-width": 2
       }
+    },
+    {
+      "id": "building-name",
+      "type": "symbol",
+      "metadata": {"mapbox:group": "1444849364238.8171"},
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "minzoom": 15,
+      "filter": ["has", "name"],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-padding": 2,
+        "text-size": {"base": 1, "stops": [[15, 10], [20, 14]]},
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#4d4d4d",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
     }
   ],
   "id": "bright"


### PR DESCRIPTION
Named buildings carry no label today. In many regions a large share of the useful map labels sit on buildings serving as landmarks rather than on POI nodes, so the map reads as unlabelled where OSM does have names.

Add a "building-name" symbol layer for the building layer's name attribute:

- minzoom 15, so the labels appear only once buildings are large enough to carry text.
- Placed last, after the place labels. MapLibre and Mapbox GL place symbols in layer order, so every POI and place label wins a collision against a building name. A building tagged as a POI is labelled by the poi layer instead of twice.
- text-field is "{name}" rather than "{name:latin}\n{name:nonlatin}": the building layer exposes a plain name attribute only.

This needs the name attribute on the building layer, which OpenMapTiles does not emit yet - see openmaptiles/openmaptiles#241 / https://github.com/openmaptiles/openmaptiles/pull/1812. Without it the layer matches nothing and the style is unchanged, so it is safe to merge ahead of the schema.

Disclaimer: PR was aided by Claude Code